### PR TITLE
Changing appearance immediately when the computer wakes up

### DIFF
--- a/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.h
+++ b/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.h
@@ -16,10 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)activate;
 - (void)invalidate;
+- (void)update;
 
 @property (nonatomic, readonly) BOOL isPresent;
 
 + (BOOL)hardwareUsesLegacySensor;
+
 
 @end
 

--- a/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.m
+++ b/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.m
@@ -68,6 +68,11 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
     return _event;
 }
 
+- (void)update
+{
+    [self _read];
+}
+
 - (void)_read
 {
     if (!self.event) {

--- a/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensorReader.swift
+++ b/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensorReader.swift
@@ -52,6 +52,10 @@ public final class DMBAmbientLightSensorReader: ObservableObject {
         sensor.invalidate()
     }
     
+    public func update() {
+        sensor.update()
+    }
+    
     deinit { invalidate() }
     
 }

--- a/DarkModeBuddyCore/Source/Storage/DMBSettings.swift
+++ b/DarkModeBuddyCore/Source/Storage/DMBSettings.swift
@@ -17,6 +17,7 @@ public final class DMBSettings: ObservableObject {
         static let ambientLightSmoothingConstant = "ambientLightSmoothingConstant"
         static let hasLaunchedAppBefore = "hasLaunchedAppBefore"
         static let disableAppearanceChangeInClamshellMode = "disableAppearanceChangeInClamshellMode"
+        static let enableImmediateChangeOnComputerWake = "enableImmediateChangeOnComputerWake"
         
         static let defaultDarknessThreshold: Double = {
             DMBAmbientLightSensor.hardwareUsesLegacySensor() ? 20.0 : 52.0
@@ -42,7 +43,8 @@ public final class DMBSettings: ObservableObject {
             Keys.isChangeSystemAppearanceBasedOnAmbientLightEnabled: true,
             Keys.darknessThresholdIntervalInSeconds: Keys.defaultDarknessThresholdIntervalInSeconds,
             Keys.ambientLightSmoothingConstant: Keys.defaultAmbientLightSmoothingConstant,
-            Keys.disableAppearanceChangeInClamshellMode: true
+            Keys.disableAppearanceChangeInClamshellMode: true,
+            Keys.enableImmediateChangeOnComputerWake: true
         ])
         
         self.isChangeSystemAppearanceBasedOnAmbientLightEnabled = defaults.bool(forKey: Keys.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
@@ -64,6 +66,10 @@ public final class DMBSettings: ObservableObject {
     
     var isDisableAppearanceChangeInClamshellModeEnabled: Bool {
         defaults.bool(forKey: Keys.disableAppearanceChangeInClamshellMode)
+    }
+    
+    var isImmediateChangeOnComputerWakeEnabled: Bool {
+        defaults.bool(forKey: Keys.enableImmediateChangeOnComputerWake)
     }
     
     @Published public var hasLaunchedAppBefore: Bool {


### PR DESCRIPTION
When the Mac has been asleep then wakes up, the app will now change the appearance to match the current ambient light conditions immediately. This addresses the very common use case of putting the Mac to sleep at night then opening it up the next morning, at which point the ambient will likely be brighter and the user expects the change to be immediate.

Still needs some QA and possibly adjustments in the delay, since while opening the lid on a portable Mac it is possible for the user to accidentally cover the ambient light sensor, which could cause an unintended change into Dark Mode. A better strategy could be to observe the ambient light value very quickly within the first 5 seconds of wake and take an average.