### PR TITLE
Don't act when there is no data

### DIFF
--- a/DarkModeBuddyCore/Source/System/DMBSystemAppearanceSwitcher.swift
+++ b/DarkModeBuddyCore/Source/System/DMBSystemAppearanceSwitcher.swift
@@ -116,6 +116,8 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
         os_log("%{public}@ %{public}.2f", log: log, type: .debug, #function, value)
         #endif
         
+        guard value != -1 else { return }
+        
         let newAppearance: Appearance
         
         if value < settings.darknessThreshold {


### PR DESCRIPTION
In some circumstances (e.g. the Mac's displays are off), the light sensor doesn't return any data, which we interpret as a brightness value of -1. When that happens, we shouldn't take action based on that value.

The behavior was observed on a 2021 MacBook Pro running macOS 12.1.
