### PR TITLE
Improve time formatting and slider

### DIFF
--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -93,7 +93,7 @@ struct SettingsView: View {
                     HStack(alignment: .firstTextBaseline) {
                         Slider(value: $settings.darknessThresholdIntervalInSeconds, in: 10...600)
                             .frame(maxWidth: 300)
-                        Text("\(settings.darknessThresholdIntervalInSeconds.formattedNoFractionDigits) s")
+                        Text(settings.darknessThresholdIntervalInSeconds.formattedTime)
                             .font(.system(size: 12, weight: .medium).monospacedDigit())
                     }
                 }
@@ -123,6 +123,11 @@ extension NumberFormatter {
 extension Double {
     var formattedNoFractionDigits: String {
         NumberFormatter.noFractionDigits.string(from: NSNumber(value: self)) ?? "!!!"
+    }
+    var formattedTime: String {
+        var formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: self) ?? "!!!"
     }
 }
 

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -91,10 +91,10 @@ struct SettingsView: View {
                         .padding(.top, 22)
                     
                     HStack(alignment: .firstTextBaseline) {
-                        Slider(value: $settings.darknessThresholdIntervalInSeconds, in: 10...600)
-                            .frame(maxWidth: 300)
+                        Slider(value: $settings.darknessThresholdIntervalInSeconds, in: 15...600, step: 15)
                         Text(settings.darknessThresholdIntervalInSeconds.formattedTime)
                             .font(.system(size: 12, weight: .medium).monospacedDigit())
+                            .frame(width: 50, alignment: .trailing)
                     }
                 }
             }
@@ -125,8 +125,13 @@ extension Double {
         NumberFormatter.noFractionDigits.string(from: NSNumber(value: self)) ?? "!!!"
     }
     var formattedTime: String {
-        var formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .abbreviated
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        return (formatter.string(from: self) ?? "!!!" ) + "s"
+    }
+    var formattedLongTime: String {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
         return formatter.string(from: self) ?? "!!!"
     }
 }
@@ -137,7 +142,7 @@ extension DMBSettings {
             return "Dark Mode will not be enabled automatically based on ambient light."
         }
         
-        return "Dark Mode will be enabled when the ambient light stays below \(darknessThreshold.formattedNoFractionDigits) for over \(darknessThresholdIntervalInSeconds.formattedNoFractionDigits) seconds."
+        return "Dark Mode will be enabled when the ambient light stays below \(darknessThreshold.formattedNoFractionDigits) for over \(darknessThresholdIntervalInSeconds.formattedLongTime)."
     }
 }
 


### PR DESCRIPTION
I wanted to set Delay Time to 5 minutes and thought it was too hard.

So I've done these changes:
- add 15 seconds step to the slider
- format the Delay Time in "min:sec", using the short or long format where appropriate
- adjust the layout to make the above changes flow nicely