### PR TITLE
Feature: Time-based constraints for dark mode switching

### DIFF
--- a/DarkModeBuddy.xcodeproj/project.pbxproj
+++ b/DarkModeBuddy.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA00000125F00001001BB982 /* SolarCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000025F00001001BB982 /* SolarCalculator.swift */; };
+		AA00000325F00002001BB982 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000225F00002001BB982 /* LocationManager.swift */; };
+		AA00000525F00003001BB982 /* TimeScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000425F00003001BB982 /* TimeScheduleManager.swift */; };
 		F479410A25E5EA5A001BB982 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F479410925E5EA5A001BB982 /* AppDelegate.swift */; };
 		F479410C25E5EA5A001BB982 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F479410B25E5EA5A001BB982 /* SettingsView.swift */; };
 		F479410E25E5EA5B001BB982 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F479410D25E5EA5B001BB982 /* Assets.xcassets */; };
@@ -56,6 +59,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AA00000025F00001001BB982 /* SolarCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolarCalculator.swift; sourceTree = "<group>"; };
+		AA00000225F00002001BB982 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		AA00000425F00003001BB982 /* TimeScheduleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeScheduleManager.swift; sourceTree = "<group>"; };
 		F479410625E5EA5A001BB982 /* DarkModeBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DarkModeBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F479410925E5EA5A001BB982 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F479410B25E5EA5A001BB982 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -201,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				F479413C25E5EBAE001BB982 /* DMBSystemAppearanceSwitcher.swift */,
+				AA00000425F00003001BB982 /* TimeScheduleManager.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -239,6 +246,8 @@
 				F479416725E6C408001BB982 /* SharedFileList.h */,
 				F479416625E6C408001BB982 /* SharedFileList.m */,
 				F4EEE7B525E7D58E005E840B /* ClamshellStateChecker.swift */,
+				AA00000025F00001001BB982 /* SolarCalculator.swift */,
+				AA00000225F00002001BB982 /* LocationManager.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -393,6 +402,9 @@
 				F479413D25E5EBAE001BB982 /* DMBSystemAppearanceSwitcher.swift in Sources */,
 				F479416D25E6D24C001BB982 /* DMBAmbientLightSensor.m in Sources */,
 				F4EEE7B625E7D58E005E840B /* ClamshellStateChecker.swift in Sources */,
+				AA00000125F00001001BB982 /* SolarCalculator.swift in Sources */,
+				AA00000325F00002001BB982 /* LocationManager.swift in Sources */,
+				AA00000525F00003001BB982 /* TimeScheduleManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DarkModeBuddy.xcodeproj/xcshareddata/xcschemes/DarkModeBuddy.xcscheme
+++ b/DarkModeBuddy.xcodeproj/xcshareddata/xcschemes/DarkModeBuddy.xcscheme
@@ -53,7 +53,7 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-ShowSettings YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-DMBFakeSystemUsesLegacySensor YES"

--- a/DarkModeBuddy/Bootstrap/AppDelegate.swift
+++ b/DarkModeBuddy/Bootstrap/AppDelegate.swift
@@ -14,31 +14,46 @@ import Sparkle
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     var window: NSWindow!
-    
-    let settings = DMBSettings()
+
+    lazy var settings = DMBSettings()
+    lazy var locationManager = LocationManager()
+
+    lazy var timeScheduleManager: TimeScheduleManager = {
+        TimeScheduleManager(settings: settings, locationManager: locationManager)
+    }()
 
     lazy var switcher: DMBSystemAppearanceSwitcher = {
-        DMBSystemAppearanceSwitcher(settings: settings)
+        let s = DMBSystemAppearanceSwitcher(settings: settings)
+        s.timeScheduleManager = timeScheduleManager
+        return s
     }()
-    
+
     private var shouldShowUI: Bool {
         !settings.hasLaunchedAppBefore
         || shouldShowSettingsOnNextLaunch
         || UserDefaults.standard.bool(forKey: "ShowSettings")
     }
-    
+
     func applicationWillFinishLaunching(_ notification: Notification) {
+        guard !isRunningInPreview else { return }
         SUUpdater.shared()?.delegate = self
     }
 
+    private var isRunningInPreview: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PLAYGROUNDS"] != nil
+    }
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        guard !isRunningInPreview else { return }
+
         if shouldShowUI {
             settings.hasLaunchedAppBefore = true
             showSettingsWindow(nil)
         }
-        
+
+        timeScheduleManager.activate()
         switcher.activate()
-        
+
         NSWorkspace.shared.notificationCenter.addObserver(
             self,
             selector: #selector(receivedShutdownNotification),
@@ -46,12 +61,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil
         )
     }
-    
+
     private lazy var sensorReader = DMBAmbientLightSensorReader(frequency: .realtime)
 
     @IBAction func showSettingsWindow(_ sender: Any?) {
         NSApp.setActivationPolicy(.regular)
-        
+
         window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 385, height: 360),
             styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
@@ -63,23 +78,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isMovableByWindowBackground = true
         window.delegate = self
         window.isReleasedWhenClosed = false
-        
+
         let view = SettingsView()
             .environmentObject(sensorReader)
             .environmentObject(settings)
-        
+            .environmentObject(locationManager)
+            .environmentObject(timeScheduleManager)
+
         window.contentView = NSHostingView(rootView: view)
-        
+
         window.makeKeyAndOrderFront(nil)
         window.center()
-        
+
         NSApp.activate(ignoringOtherApps: true)
     }
-    
+
     @IBAction func terminate(_ sender: Any?) {
         // No need to confirm on quit if the user's Mac is not supported.
         shouldSkipTerminationConfirmation = !sensorReader.isSensorReady
-        
+
         NSApp.terminate(sender)
     }
 
@@ -90,21 +107,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         guard !isShowingSettingsWindow else { return true }
-        
+
         showSettingsWindow(nil)
-        
+
         return true
     }
-    
+
     private var shouldShowSettingsOnNextLaunch: Bool {
         get {
             let value = UserDefaults.standard.bool(forKey: #function)
-            
+
             if value {
                 // Reset flag
                 UserDefaults.standard.set(false, forKey: #function)
             }
-            
+
             return value
         }
         set {
@@ -112,11 +129,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             UserDefaults.standard.synchronize()
         }
     }
-    
+
     private var shouldSkipTerminationConfirmation = false
-    
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        guard !shouldSkipTerminationConfirmation else { return .terminateNow }
+        guard !shouldSkipTerminationConfirmation else {
+            switcher.restoreMacOSAutoDarkMode()
+            return .terminateNow
+        }
 
         let alert = NSAlert()
         alert.messageText = "Quit DarkModeBuddy?"
@@ -127,14 +147,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let result = alert.runModal()
 
         if result == .alertSecondButtonReturn {
+            switcher.restoreMacOSAutoDarkMode()
             return .terminateNow
         } else {
             window?.close()
-            
+
             return .terminateCancel
         }
     }
-    
+
     @objc func receivedShutdownNotification(_ note: Notification) {
         shouldSkipTerminationConfirmation = true
     }
@@ -145,21 +166,21 @@ extension AppDelegate: NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
-        
+
         window = nil
     }
-    
+
 }
 
 extension AppDelegate: SUUpdaterDelegate {
-    
+
     func updaterWillRelaunchApplication(_ updater: SUUpdater) {
         shouldSkipTerminationConfirmation = true
         shouldShowSettingsOnNextLaunch = true
     }
-    
+
     func updater(_ updater: SUUpdater, didCancelInstallUpdateOnQuit item: SUAppcastItem) {
         shouldSkipTerminationConfirmation = false
     }
-    
+
 }

--- a/DarkModeBuddy/Bootstrap/AppDelegate.swift
+++ b/DarkModeBuddy/Bootstrap/AppDelegate.swift
@@ -27,13 +27,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         s.timeScheduleManager = timeScheduleManager
         return s
     }()
-
+    
     private var shouldShowUI: Bool {
         !settings.hasLaunchedAppBefore
         || shouldShowSettingsOnNextLaunch
         || UserDefaults.standard.bool(forKey: "ShowSettings")
     }
-
+    
     func applicationWillFinishLaunching(_ notification: Notification) {
         guard !isRunningInPreview else { return }
         SUUpdater.shared()?.delegate = self
@@ -50,7 +50,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             settings.hasLaunchedAppBefore = true
             showSettingsWindow(nil)
         }
-
+        
         timeScheduleManager.activate()
         switcher.activate()
 
@@ -61,14 +61,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil
         )
     }
-
+    
     private lazy var sensorReader = DMBAmbientLightSensorReader(frequency: .realtime)
 
     @IBAction func showSettingsWindow(_ sender: Any?) {
         NSApp.setActivationPolicy(.regular)
-
+        
         window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 385, height: 360),
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 580),
             styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
             backing: .buffered, defer: false)
         window.center()
@@ -78,25 +78,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         window.isMovableByWindowBackground = true
         window.delegate = self
         window.isReleasedWhenClosed = false
-
+        
         let view = SettingsView()
             .environmentObject(sensorReader)
             .environmentObject(settings)
             .environmentObject(locationManager)
             .environmentObject(timeScheduleManager)
-
-        window.contentView = NSHostingView(rootView: view)
-
+        
+        let hostingController = AutoSizingHostingController(rootView: view)
+        window.contentViewController = hostingController
+        
         window.makeKeyAndOrderFront(nil)
         window.center()
-
+        
         NSApp.activate(ignoringOtherApps: true)
     }
-
+    
     @IBAction func terminate(_ sender: Any?) {
         // No need to confirm on quit if the user's Mac is not supported.
         shouldSkipTerminationConfirmation = !sensorReader.isSensorReady
-
+        
         NSApp.terminate(sender)
     }
 
@@ -107,21 +108,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         guard !isShowingSettingsWindow else { return true }
-
+        
         showSettingsWindow(nil)
-
+        
         return true
     }
-
+    
     private var shouldShowSettingsOnNextLaunch: Bool {
         get {
             let value = UserDefaults.standard.bool(forKey: #function)
-
+            
             if value {
                 // Reset flag
                 UserDefaults.standard.set(false, forKey: #function)
             }
-
+            
             return value
         }
         set {
@@ -129,9 +130,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             UserDefaults.standard.synchronize()
         }
     }
-
+    
     private var shouldSkipTerminationConfirmation = false
-
+    
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard !shouldSkipTerminationConfirmation else {
             switcher.restoreMacOSAutoDarkMode()
@@ -151,11 +152,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return .terminateNow
         } else {
             window?.close()
-
+            
             return .terminateCancel
         }
     }
-
+    
     @objc func receivedShutdownNotification(_ note: Notification) {
         shouldSkipTerminationConfirmation = true
     }
@@ -166,21 +167,36 @@ extension AppDelegate: NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
-
+        
         window = nil
     }
+    
+}
 
+final class AutoSizingHostingController<Content: View>: NSHostingController<Content> {
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        guard let window = view.window else { return }
+        let fittingSize = view.fittingSize
+        let targetSize = NSSize(
+            width: max(fittingSize.width, 420),
+            height: fittingSize.height
+        )
+        if window.contentView?.frame.size != targetSize {
+            window.setContentSize(targetSize)
+        }
+    }
 }
 
 extension AppDelegate: SUUpdaterDelegate {
-
+    
     func updaterWillRelaunchApplication(_ updater: SUUpdater) {
         shouldSkipTerminationConfirmation = true
         shouldShowSettingsOnNextLaunch = true
     }
-
+    
     func updater(_ updater: SUUpdater, didCancelInstallUpdateOnQuit item: SUAppcastItem) {
         shouldSkipTerminationConfirmation = false
     }
-
+    
 }

--- a/DarkModeBuddy/Resources/DarkModeBuddy.entitlements
+++ b/DarkModeBuddy/Resources/DarkModeBuddy.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+</dict>
 </plist>

--- a/DarkModeBuddy/Resources/Info.plist
+++ b/DarkModeBuddy/Resources/Info.plist
@@ -26,6 +26,10 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSLocationUsageDescription</key>
+	<string>DarkModeBuddy needs your location to calculate sunrise and sunset times for time-based dark mode scheduling.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>DarkModeBuddy needs your location to calculate sunrise and sunset times for time-based dark mode scheduling.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -8,6 +8,17 @@
 import SwiftUI
 import DarkModeBuddyCore
 
+private extension View {
+    @ViewBuilder
+    func disabledAppearance(_ isDisabled: Bool) -> some View {
+        if isDisabled {
+            self.foregroundColor(Color(NSColor.disabledControlTextColor))
+        } else {
+            self
+        }
+    }
+}
+
 struct SettingsView: View {
     @EnvironmentObject var reader: DMBAmbientLightSensorReader
     @EnvironmentObject var settings: DMBSettings
@@ -34,6 +45,7 @@ struct SettingsView: View {
     }()
 
     var body: some View {
+
         Group {
             if reader.isSensorReady {
                 settingsControls
@@ -41,27 +53,32 @@ struct SettingsView: View {
                 UnsupportedMacView()
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding([.top, .bottom])
+        .fixedSize(horizontal: true, vertical: true)
+        .padding([.top, .bottom], 22)
         .padding([.leading, .trailing], 22)
-        .onAppear { reader.activate() }
+        .onAppear {
+            reader.activate()
+            if settings.timeScheduleMode != .disabled {
+                selectedTimeMode = settings.timeScheduleMode
+            }
+        }
     }
 
     private var settingsControls: some View {
         VStack(alignment: .leading, spacing: 32) {
             Toggle(
-                "Launch at Login",
+                "Launch at login",
                 isOn: $settings.isLaunchAtLoginEnabled
             )
 
             Toggle(
-                "Change Theme Automatically",
+                "Change theme automatically",
                 isOn: $settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled
             )
 
             Group {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Go Dark When Ambient Light Falls Below:")
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Go dark when ambient light falls below:")
 
                     HStack(alignment: .firstTextBaseline) {
                         Slider(value: $settings.darknessThreshold, in: darknessInterval)
@@ -101,7 +118,7 @@ struct SettingsView: View {
                         .padding(.bottom, 5)
 
                     HStack(alignment: .firstTextBaseline) {
-                        Text("Current Ambient Light Level:")
+                        Text("Current ambient light level:")
                         Text("\(reader.ambientLightValue.formattedNoFractionDigits)")
                             .font(.system(size: 12).monospacedDigit())
                     }
@@ -146,9 +163,30 @@ struct SettingsView: View {
                 }
             }
             .disabled(!settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
+            .disabledAppearance(!settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
 
             statusLineView
         }
+    }
+
+    // MARK: - Duration Slider Binding
+
+    private var durationSliderBinding: Binding<Double> {
+        Binding(
+            get: {
+                let steps = Self.durationSteps
+                let value = settings.darknessThresholdIntervalInSeconds
+                // Find the closest step index
+                let idx = steps.enumerated().min(by: { abs($0.element - value) < abs($1.element - value) })?.offset ?? 0
+                return Double(idx)
+            },
+            set: { newIndex in
+                let idx = Int(newIndex.rounded())
+                let steps = Self.durationSteps
+                guard idx >= 0 && idx < steps.count else { return }
+                settings.darknessThresholdIntervalInSeconds = steps[idx]
+            }
+        )
     }
 
     // MARK: - Time Constraints Bindings
@@ -174,26 +212,6 @@ struct SettingsView: View {
                 if settings.timeScheduleMode != .disabled {
                     settings.timeScheduleMode = newMode
                 }
-            }
-        )
-    }
-
-    // MARK: - Duration Slider Binding
-
-    private var durationSliderBinding: Binding<Double> {
-        Binding(
-            get: {
-                let steps = Self.durationSteps
-                let value = settings.darknessThresholdIntervalInSeconds
-                // Find the closest step index
-                let idx = steps.enumerated().min(by: { abs($0.element - value) < abs($1.element - value) })?.offset ?? 0
-                return Double(idx)
-            },
-            set: { newIndex in
-                let idx = Int(newIndex.rounded())
-                let steps = Self.durationSteps
-                guard idx >= 0 && idx < steps.count else { return }
-                settings.darknessThresholdIntervalInSeconds = steps[idx]
             }
         )
     }
@@ -253,7 +271,7 @@ struct SettingsView: View {
                             }
                         }
                         .frame(width: 180, alignment: .leading)
-
+                        
                         HStack {
                             Text("Start:").frame(width: 35, alignment: .leading)
                             if #available(macOS 26.0, *) {
@@ -268,7 +286,7 @@ struct SettingsView: View {
                             }
                         }
                         .frame(width: 180, alignment: .leading)
-
+                        
                         HStack {
                             Text("End:")
                                 .frame(width: 35, alignment: .leading)
@@ -282,7 +300,7 @@ struct SettingsView: View {
                     if locationManager.hasLocation {
                         solarTimesDisplay
                     }
-
+                
             }
 
             if !locationManager.hasLocation {
@@ -326,24 +344,6 @@ struct SettingsView: View {
                 .font(.system(size: 11))
                 .foregroundColor(Color(NSColor.secondaryLabelColor))
             }
-        }
-    }
-
-    // MARK: - Helpers
-
-    private func sunsetLabel(for offset: SolarOffset) -> String {
-        switch offset.rawValue {
-        case let v where v < 0: return "\(offset.label) before sunset"
-        case 0: return "At sunset"
-        default: return "\(offset.label) after sunset"
-        }
-    }
-
-    private func sunriseLabel(for offset: SolarOffset) -> String {
-        switch offset.rawValue {
-        case let v where v < 0: return "\(offset.label) before sunrise"
-        case 0: return "At sunrise"
-        default: return "\(offset.label) after sunrise"
         }
     }
 
@@ -458,15 +458,33 @@ struct SettingsView: View {
                 .position(x: xPosition, y: geometry.size.height / 2)
         }
     }
+
+    // MARK: - Helpers
+
+    private func sunsetLabel(for offset: SolarOffset) -> String {
+        switch offset.rawValue {
+        case let v where v < 0: return "\(offset.label) before sunset"
+        case 0: return "At sunset"
+        default: return "\(offset.label) after sunset"
+        }
+    }
+
+    private func sunriseLabel(for offset: SolarOffset) -> String {
+        switch offset.rawValue {
+        case let v where v < 0: return "\(offset.label) before sunrise"
+        case 0: return "At sunrise"
+        default: return "\(offset.label) after sunrise"
+        }
+    }
 }
 
 extension NumberFormatter {
     static let noFractionDigits: NumberFormatter = {
         let f = NumberFormatter()
-
+        
         f.numberStyle = .decimal
         f.maximumFractionDigits = 0
-
+        
         return f
     }()
 }

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @State private var isShowingDarknessValueOutOfBoundsAlert = false
     @State private var isEditingAmbientLightLevelManually = false
     @State private var editingAmbientLightManuallyTextFieldStore = ""
+    @State private var selectedTimeMode: TimeScheduleMode = .fixedTime
 
     private static let hourOptions = Array(0...23)
     private static let minuteOptions = [0, 15, 30, 45]
@@ -110,7 +111,20 @@ struct SettingsView: View {
                         .padding(.top, 16)
 
                     if settings.timeScheduleMode != .disabled {
-                        fixedTimeControls
+                        Picker("Only change theme within:", selection: timeModePickerBinding) {
+                            Text("Fixed time window").tag(TimeScheduleMode.fixedTime)
+                            Text("Relative to sunset/sunrise").tag(TimeScheduleMode.solarRelative)
+                        }
+                        .pickerStyle(RadioGroupPickerStyle())
+                        .padding(.leading, 8)
+
+                        if selectedTimeMode == .fixedTime {
+                            fixedTimeControls
+                        }
+
+                        if selectedTimeMode == .solarRelative {
+                            solarRelativeControls
+                        }
                     }
                 }
             }
@@ -131,9 +145,21 @@ struct SettingsView: View {
             get: { settings.timeScheduleMode != .disabled },
             set: { enabled in
                 if enabled {
-                    settings.timeScheduleMode = .fixedTime
+                    settings.timeScheduleMode = selectedTimeMode
                 } else {
                     settings.timeScheduleMode = .disabled
+                }
+            }
+        )
+    }
+
+    private var timeModePickerBinding: Binding<TimeScheduleMode> {
+        Binding(
+            get: { selectedTimeMode },
+            set: { newMode in
+                selectedTimeMode = newMode
+                if settings.timeScheduleMode != .disabled {
+                    settings.timeScheduleMode = newMode
                 }
             }
         )
@@ -180,6 +206,112 @@ struct SettingsView: View {
             }
         }
         .padding(.leading, 8)
+    }
+
+    // MARK: - Solar Relative Controls
+
+    private var solarRelativeControls: some View {
+        VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    VStack(alignment: .leading, spacing: 6){
+                        let startDropdown = Picker("", selection: $settings.sunsetOffsetMinutes) {
+                            ForEach(SolarOffset.allCases) { offset in
+                                Text(sunsetLabel(for: offset)).tag(offset.rawValue)
+                            }
+                        }
+                        .frame(width: 180, alignment: .leading)
+
+                        HStack {
+                            Text("Start:").frame(width: 35, alignment: .leading)
+                            if #available(macOS 26.0, *) {
+                                startDropdown.buttonSizing(.flexible)
+                            } else {
+                                startDropdown
+                            }
+                        }
+                        let endDropdown = Picker("", selection: $settings.sunriseOffsetMinutes) {
+                            ForEach(SolarOffset.allCases) { offset in
+                                Text(sunriseLabel(for: offset)).tag(offset.rawValue)
+                            }
+                        }
+                        .frame(width: 180, alignment: .leading)
+
+                        HStack {
+                            Text("End:")
+                                .frame(width: 35, alignment: .leading)
+                            if #available(macOS 26.0, *) {
+                                endDropdown.buttonSizing(.flexible)
+                            } else {
+                                endDropdown
+                            }
+                        }
+                    }
+                    if locationManager.hasLocation {
+                        solarTimesDisplay
+                    }
+
+            }
+
+            if !locationManager.hasLocation {
+                HStack(spacing: 10) {
+                    Text("\u{26A0} Location required for sunrise/sunset calculation.")
+                        .font(.system(size: 11))
+                        .foregroundColor(.orange)
+                    Button("Grant permission") {
+                        locationManager.requestPermission()
+                    }
+                    .font(.system(size: 11))
+                }.frame(height: 30, alignment: .trailing)
+            }
+
+            if let error = locationManager.locationError {
+                Text("Location error: \(error)")
+                    .font(.system(size: 11))
+                    .foregroundColor(.red)
+            }
+        }
+        .padding(.leading, 8)
+    }
+
+    private var solarTimesDisplay: some View {
+        VStack(alignment: .center, spacing: 13) {
+            if let sunset = timeScheduleManager.computedSunset {
+                HStack(spacing: 4) {
+                    Text("Adjusted time:")
+                    Text(sunset.formattedTime)
+                        .fontWeight(.medium)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(Color(NSColor.secondaryLabelColor))
+            }
+            if let sunrise = timeScheduleManager.computedSunrise {
+                HStack(spacing: 4) {
+                    Text("Adjusted time:")
+                    Text(sunrise.formattedTime)
+                        .fontWeight(.medium)
+                }
+                .font(.system(size: 11))
+                .foregroundColor(Color(NSColor.secondaryLabelColor))
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sunsetLabel(for offset: SolarOffset) -> String {
+        switch offset.rawValue {
+        case let v where v < 0: return "\(offset.label) before sunset"
+        case 0: return "At sunset"
+        default: return "\(offset.label) after sunset"
+        }
+    }
+
+    private func sunriseLabel(for offset: SolarOffset) -> String {
+        switch offset.rawValue {
+        case let v where v < 0: return "\(offset.label) before sunrise"
+        case 0: return "At sunrise"
+        default: return "\(offset.label) after sunrise"
+        }
     }
 }
 

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -147,11 +147,7 @@ struct SettingsView: View {
             }
             .disabled(!settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
 
-            Text(settings.currentSettingsDescription)
-                .font(.system(size: 11))
-                .foregroundColor(Color(NSColor.tertiaryLabelColor))
-//                .multilineTextAlignment(.center)
-                .lineLimit(nil)
+            statusLineView
         }
     }
 
@@ -351,6 +347,100 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Status Line
+
+    private var statusLineView: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Circle()
+                .fill(statusBulletColor)
+                .frame(width: 8, height: 8)
+                .padding(.top, 3)
+            Text(statusText)
+                .font(.system(size: 11))
+                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 350, minHeight: 40, alignment: .topLeading)
+        }
+    }
+
+    private var statusBulletColor: Color {
+        if !settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled {
+            return .gray
+        }
+        if settings.timeScheduleMode != .disabled && !timeScheduleManager.isWithinSchedule {
+            return .gray
+        }
+        return .green
+    }
+
+    private var statusText: String {
+        guard settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled else {
+            let isAuto = UserDefaults.standard.bool(forKey: "AppleInterfaceStyleSwitchesAutomatically")
+            if isAuto {
+                return "DarkModeBuddy is off, switching is managed by macOS."
+            }
+            let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            if isDark {
+                return "DarkModeBuddy is off, dark mode is set by macOS."
+            }
+            return "DarkModeBuddy is off, light mode is set by macOS."
+        }
+
+        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let threshold = settings.darknessThreshold.formattedNoFractionDigits
+        let duration = settings.darknessThresholdIntervalInSeconds.formattedLongTime
+        let timeConstraintsOn = settings.timeScheduleMode != .disabled
+
+        if timeConstraintsOn {
+            if !timeScheduleManager.isWithinSchedule {
+                let startTime = scheduleStartTimeString
+                return "Automatic switching is temporarily disabled until \(startTime). After that, dark mode will be enabled when ambient light stays below \(threshold) for over \(duration)."
+            } else {
+                let endTime = scheduleEndTimeString
+                if isDark {
+                    return "Automatic switching is active until \(endTime). Light mode will be enabled when ambient light stays above \(threshold) for over \(duration), or at \(endTime)."
+                } else {
+                    return "Automatic switching is active until \(endTime). Dark mode will be enabled when ambient light stays below \(threshold) for over \(duration)."
+                }
+            }
+        } else {
+            if isDark {
+                return "Automatic switching is active. Light mode will be enabled when ambient light stays above \(threshold) for over \(duration)."
+            } else {
+                return "Automatic switching is active. Dark mode will be enabled when ambient light stays below \(threshold) for over \(duration)."
+            }
+        }
+    }
+
+    private var scheduleStartTimeString: String {
+        switch settings.timeScheduleMode {
+        case .fixedTime:
+            return String(format: "%02d:%02d", settings.fixedStartHour, settings.fixedStartMinute)
+        case .solarRelative:
+            if let sunset = timeScheduleManager.computedSunset {
+                return sunset.formattedTime
+            }
+            return "\u{2014}"
+        case .disabled:
+            return "\u{2014}"
+        }
+    }
+
+    private var scheduleEndTimeString: String {
+        switch settings.timeScheduleMode {
+        case .fixedTime:
+            return String(format: "%02d:%02d", settings.fixedEndHour, settings.fixedEndMinute)
+        case .solarRelative:
+            if let sunrise = timeScheduleManager.computedSunrise {
+                return sunrise.formattedTime
+            }
+            return "\u{2014}"
+        case .disabled:
+            return "\u{2014}"
+        }
+    }
+
     // MARK: - Current Light Indicator
 
     private var currentLightIndicator: some View {
@@ -404,16 +494,6 @@ extension Date {
         f.dateStyle = .none
         f.timeStyle = .short
         return f.string(from: self)
-    }
-}
-
-extension DMBSettings {
-    var currentSettingsDescription: String {
-        guard isChangeSystemAppearanceBasedOnAmbientLightEnabled else {
-            return "Dark Mode will not be enabled automatically based on ambient light."
-        }
-
-        return "Dark Mode will be enabled when the ambient light stays below \(darknessThreshold.formattedNoFractionDigits) for over \(darknessThresholdIntervalInSeconds.formattedLongTime)."
     }
 }
 

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -11,13 +11,18 @@ import DarkModeBuddyCore
 struct SettingsView: View {
     @EnvironmentObject var reader: DMBAmbientLightSensorReader
     @EnvironmentObject var settings: DMBSettings
+    @EnvironmentObject var locationManager: LocationManager
+    @EnvironmentObject var timeScheduleManager: TimeScheduleManager
 
     private let darknessInterval: ClosedRange<Double> = 0...3000
 
     @State private var isShowingDarknessValueOutOfBoundsAlert = false
     @State private var isEditingAmbientLightLevelManually = false
     @State private var editingAmbientLightManuallyTextFieldStore = ""
-    
+
+    private static let hourOptions = Array(0...23)
+    private static let minuteOptions = [0, 15, 30, 45]
+
     var body: some View {
         Group {
             if reader.isSensorReady {
@@ -31,23 +36,23 @@ struct SettingsView: View {
         .padding([.leading, .trailing], 22)
         .onAppear { reader.activate() }
     }
-    
+
     private var settingsControls: some View {
         VStack(alignment: .leading, spacing: 32) {
             Toggle(
                 "Launch at Login",
                 isOn: $settings.isLaunchAtLoginEnabled
             )
-            
+
             Toggle(
                 "Change Theme Automatically",
                 isOn: $settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled
             )
-            
+
             Group {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Go Dark When Ambient Light Falls Below:")
-                    
+
                     HStack(alignment: .firstTextBaseline) {
                         Slider(value: $settings.darknessThreshold, in: darknessInterval)
                             .frame(maxWidth: 300)
@@ -77,7 +82,7 @@ struct SettingsView: View {
                               message: Text("The threshold value must be in the interval [\(darknessInterval.lowerBound.formattedNoFractionDigits), \(darknessInterval.upperBound.formattedNoFractionDigits)]"),
                               dismissButton: .default(Text("OK")))
                     }
-                    
+
                     HStack(alignment: .firstTextBaseline) {
                         Text("Current Ambient Light Level:")
                         Text("\(reader.ambientLightValue.formattedNoFractionDigits)")
@@ -85,11 +90,11 @@ struct SettingsView: View {
                     }
                     .font(.system(size: 12))
                     .foregroundColor(Color(NSColor.secondaryLabelColor))
-                    
-                    
+
+
                     Text("Delay Time:")
                         .padding(.top, 22)
-                    
+
                     HStack(alignment: .firstTextBaseline) {
                         Slider(value: $settings.darknessThresholdIntervalInSeconds, in: 15...600, step: 15)
                         Text(settings.darknessThresholdIntervalInSeconds.formattedTime)
@@ -97,9 +102,20 @@ struct SettingsView: View {
                             .frame(width: 50, alignment: .trailing)
                     }
                 }
+
+                // MARK: - Time Constraints Section
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Time constraints", isOn: timeConstraintsBinding)
+                        .padding(.top, 16)
+
+                    if settings.timeScheduleMode != .disabled {
+                        fixedTimeControls
+                    }
+                }
             }
             .disabled(!settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
-            
+
             Text(settings.currentSettingsDescription)
                 .font(.system(size: 11))
                 .foregroundColor(Color(NSColor.tertiaryLabelColor))
@@ -107,15 +123,73 @@ struct SettingsView: View {
                 .lineLimit(nil)
         }
     }
+
+    // MARK: - Time Constraints Bindings
+
+    private var timeConstraintsBinding: Binding<Bool> {
+        Binding(
+            get: { settings.timeScheduleMode != .disabled },
+            set: { enabled in
+                if enabled {
+                    settings.timeScheduleMode = .fixedTime
+                } else {
+                    settings.timeScheduleMode = .disabled
+                }
+            }
+        )
+    }
+
+    // MARK: - Fixed Time Controls
+
+    private var fixedTimeControls: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack() {
+                Text("Start:")
+                    .frame(width: 35, alignment: .leading)
+                Picker("", selection: $settings.fixedStartHour) {
+                    ForEach(Self.hourOptions, id: \.self) { h in
+                        Text(String(format: "%02d", h)).tag(h)
+                    }
+                }
+                .frame(width: 60)
+                Text(":")
+                Picker("", selection: $settings.fixedStartMinute) {
+                    ForEach(Self.minuteOptions, id: \.self) { m in
+                        Text(String(format: "%02d", m)).tag(m)
+                    }
+                }
+                .frame(width: 60)
+            }
+
+            HStack {
+                Text("End:")
+                    .frame(width: 35, alignment: .leading)
+                Picker("", selection: $settings.fixedEndHour) {
+                    ForEach(Self.hourOptions, id: \.self) { h in
+                        Text(String(format: "%02d", h)).tag(h)
+                    }
+                }
+                .frame(width: 60)
+                Text(":")
+                Picker("", selection: $settings.fixedEndMinute) {
+                    ForEach(Self.minuteOptions, id: \.self) { m in
+                        Text(String(format: "%02d", m)).tag(m)
+                    }
+                }
+                .frame(width: 60)
+            }
+        }
+        .padding(.leading, 8)
+    }
 }
 
 extension NumberFormatter {
     static let noFractionDigits: NumberFormatter = {
         let f = NumberFormatter()
-        
+
         f.numberStyle = .decimal
         f.maximumFractionDigits = 0
-        
+
         return f
     }()
 }
@@ -136,22 +210,36 @@ extension Double {
     }
 }
 
+extension Date {
+    var formattedTime: String {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f.string(from: self)
+    }
+}
+
 extension DMBSettings {
     var currentSettingsDescription: String {
         guard isChangeSystemAppearanceBasedOnAmbientLightEnabled else {
             return "Dark Mode will not be enabled automatically based on ambient light."
         }
-        
+
         return "Dark Mode will be enabled when the ambient light stays below \(darknessThreshold.formattedNoFractionDigits) for over \(darknessThresholdIntervalInSeconds.formattedLongTime)."
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
+        let settings = DMBSettings(forPreview: true)
+        let locMgr = LocationManager()
+        let schedMgr = TimeScheduleManager(settings: settings, locationManager: locMgr)
         SettingsView()
             .frame(maxWidth: 385)
             .environmentObject(DMBAmbientLightSensorReader(frequency: .realtime))
-            .environmentObject(DMBSettings(forPreview: true))
+            .environmentObject(settings)
+            .environmentObject(locMgr)
+            .environmentObject(schedMgr)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -14,7 +14,7 @@ struct SettingsView: View {
     @EnvironmentObject var locationManager: LocationManager
     @EnvironmentObject var timeScheduleManager: TimeScheduleManager
 
-    private let darknessInterval: ClosedRange<Double> = 0...3000
+    private let darknessInterval: ClosedRange<Double> = 0...400
 
     @State private var isShowingDarknessValueOutOfBoundsAlert = false
     @State private var isEditingAmbientLightLevelManually = false
@@ -23,6 +23,15 @@ struct SettingsView: View {
 
     private static let hourOptions = Array(0...23)
     private static let minuteOptions = [0, 15, 30, 45]
+
+    // Non-linear duration steps: 5s increments to 60s, 15s to 3min, 1min to 10min
+    private static let durationSteps: [Double] = {
+        var steps = [Double]()
+        for s in stride(from: 5.0, through: 60.0, by: 5.0) { steps.append(s) }
+        for s in stride(from: 75.0, through: 180.0, by: 15.0) { steps.append(s) }
+        for s in stride(from: 240.0, through: 600.0, by: 60.0) { steps.append(s) }
+        return steps
+    }()
 
     var body: some View {
         Group {
@@ -56,7 +65,7 @@ struct SettingsView: View {
 
                     HStack(alignment: .firstTextBaseline) {
                         Slider(value: $settings.darknessThreshold, in: darknessInterval)
-                            .frame(maxWidth: 300)
+                            .frame(maxWidth: 330)
                         if isEditingAmbientLightLevelManually {
                             TextField("", text: $editingAmbientLightManuallyTextFieldStore, onCommit: {
                                 guard let newValue = Double(editingAmbientLightManuallyTextFieldStore),
@@ -68,11 +77,12 @@ struct SettingsView: View {
                                 settings.darknessThreshold = newValue
                                 isEditingAmbientLightLevelManually = false
                             })
-                            .frame(maxWidth: 40)
+                            .frame(maxWidth: 35)
                         } else {
                             Text("\(settings.darknessThreshold.formattedNoFractionDigits)")
                                 .font(.system(size: 12, weight: .medium).monospacedDigit())
-                                .onTapGesture(count: 2) {
+                                .frame(width: 35).onTapGesture(count: 2)
+                                {
                                     self.editingAmbientLightManuallyTextFieldStore = "\(settings.darknessThreshold.formattedNoFractionDigits)"
                                     isEditingAmbientLightLevelManually = true
                                 }
@@ -84,6 +94,12 @@ struct SettingsView: View {
                               dismissButton: .default(Text("OK")))
                     }
 
+                    currentLightIndicator
+                        .frame(height: 5, alignment: .leading)
+                        .frame(maxHeight: 5)
+                        .frame(maxWidth: 330)
+                        .padding(.bottom, 5)
+
                     HStack(alignment: .firstTextBaseline) {
                         Text("Current Ambient Light Level:")
                         Text("\(reader.ambientLightValue.formattedNoFractionDigits)")
@@ -93,14 +109,15 @@ struct SettingsView: View {
                     .foregroundColor(Color(NSColor.secondaryLabelColor))
 
 
-                    Text("Delay Time:")
+                    Text("Duration threshold:")
                         .padding(.top, 22)
 
                     HStack(alignment: .firstTextBaseline) {
-                        Slider(value: $settings.darknessThresholdIntervalInSeconds, in: 15...600, step: 15)
+                        Slider(value: durationSliderBinding, in: 0...Double(Self.durationSteps.count - 1), step: 1)
+                            .frame(maxWidth: 330)
                         Text(settings.darknessThresholdIntervalInSeconds.formattedTime)
                             .font(.system(size: 12, weight: .medium).monospacedDigit())
-                            .frame(width: 50, alignment: .trailing)
+                            .frame(width: 35)
                     }
                 }
 
@@ -161,6 +178,26 @@ struct SettingsView: View {
                 if settings.timeScheduleMode != .disabled {
                     settings.timeScheduleMode = newMode
                 }
+            }
+        )
+    }
+
+    // MARK: - Duration Slider Binding
+
+    private var durationSliderBinding: Binding<Double> {
+        Binding(
+            get: {
+                let steps = Self.durationSteps
+                let value = settings.darknessThresholdIntervalInSeconds
+                // Find the closest step index
+                let idx = steps.enumerated().min(by: { abs($0.element - value) < abs($1.element - value) })?.offset ?? 0
+                return Double(idx)
+            },
+            set: { newIndex in
+                let idx = Int(newIndex.rounded())
+                let steps = Self.durationSteps
+                guard idx >= 0 && idx < steps.count else { return }
+                settings.darknessThresholdIntervalInSeconds = steps[idx]
             }
         )
     }
@@ -313,6 +350,24 @@ struct SettingsView: View {
         default: return "\(offset.label) after sunrise"
         }
     }
+
+    // MARK: - Current Light Indicator
+
+    private var currentLightIndicator: some View {
+        GeometryReader { geometry in
+            let range = darknessInterval.upperBound - darknessInterval.lowerBound
+            let clampedValue = min(max(reader.ambientLightValue, darknessInterval.lowerBound), darknessInterval.upperBound)
+            let fraction = CGFloat((clampedValue - darknessInterval.lowerBound) / range)
+            let trackInset: CGFloat = 8
+            let trackWidth = geometry.size.width - trackInset * 2
+            let xPosition = trackInset + trackWidth * fraction
+
+            Text("\u{25B2}")
+                .font(.system(size: 6))
+                .foregroundColor(Color(NSColor.secondaryLabelColor))
+                .position(x: xPosition, y: geometry.size.height / 2)
+        }
+    }
 }
 
 extension NumberFormatter {
@@ -333,7 +388,8 @@ extension Double {
     var formattedTime: String {
         let formatter = DateComponentsFormatter()
         formatter.unitsStyle = .positional
-        return (formatter.string(from: self) ?? "!!!" ) + "s"
+        let str = formatter.string(from: self) ?? "!!!"
+        return self < 60 ? str + "s" : str
     }
     var formattedLongTime: String {
         let formatter = DateComponentsFormatter()

--- a/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.m
+++ b/DarkModeBuddyCore/Source/AmbientLight/DMBAmbientLightSensor.m
@@ -33,6 +33,15 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
 
 @end
 
+static BOOL DMBIsRunningInPreview(void) {
+    static BOOL _isPreview;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _isPreview = [[[NSProcessInfo processInfo] environment] objectForKey:@"XCODE_RUNNING_FOR_PLAYGROUNDS"] != nil;
+    });
+    return _isPreview;
+}
+
 @implementation DMBAmbientLightSensor
 {
     IOHIDServiceClientRef _client;
@@ -58,6 +67,7 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
 - (IOHIDEventRef)copyHIDEvent
 {
 #if DEBUG
+    if (DMBIsRunningInPreview()) return NULL;
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DMBFakeSystemUsesLegacySensor"]) return NULL;
 #endif
     
@@ -152,6 +162,7 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
 
 - (void)activate
 {
+    if (DMBIsRunningInPreview()) return;
     [self _setupUpdateTimer];
     [self _read];
 }
@@ -171,6 +182,7 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
 
 - (BOOL)isPresent
 {
+    if (DMBIsRunningInPreview()) return YES;
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"DMBFakeSensorSupported"]) return YES;
     
     return [self _canGetHIDEvent] || _legacySensorInitializedSuccessfully;
@@ -181,7 +193,11 @@ extern IOHIDServiceClientRef ALCALSCopyALSServiceClient(void);
     static BOOL _usesLegacySensor;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        _usesLegacySensor = (ALCALSCopyALSServiceClient() == NULL);
+        if (DMBIsRunningInPreview()) {
+            _usesLegacySensor = NO;
+        } else {
+            _usesLegacySensor = (ALCALSCopyALSServiceClient() == NULL);
+        }
     });
     return _usesLegacySensor;
 }

--- a/DarkModeBuddyCore/Source/Storage/DMBSettings.swift
+++ b/DarkModeBuddyCore/Source/Storage/DMBSettings.swift
@@ -8,8 +8,66 @@
 import Foundation
 import SwiftUI
 
+/// Mode for time-based scheduling of the brightness threshold.
+public enum TimeScheduleMode: Int, CaseIterable, Identifiable {
+    case disabled = 0
+    case fixedTime = 1
+    case solarRelative = 2
+
+    public var id: Int { rawValue }
+
+    public var label: String {
+        switch self {
+        case .disabled: return "Always Active"
+        case .fixedTime: return "Fixed Time Window"
+        case .solarRelative: return "Relative to Sunset/Sunrise"
+        }
+    }
+}
+
+/// Predefined offset options (in minutes) for solar-relative scheduling.
+public enum SolarOffset: Int, CaseIterable, Identifiable {
+    case minusFourHours = -240
+    case minusThreeHours = -180
+    case minusTwoHours = -120
+    case minusOneHour = -60
+    case minusFortyFive = -45
+    case minusThirty = -30
+    case minusFifteen = -15
+    case atEvent = 0
+    case plusFifteen = 15
+    case plusThirty = 30
+    case plusFortyFive = 45
+    case plusOneHour = 60
+    case plusTwoHours = 120
+    case plusThreeHours = 180
+    case plusFourHours = 240
+
+    public var id: Int { rawValue }
+
+    public var label: String {
+        let hours = abs(rawValue) / 60
+        let mins = abs(rawValue) % 60
+        if rawValue < 0 {
+            if mins == 0 {
+                return "-\(hours):00"
+            } else {
+                return "-\(hours):\(String(format: "%02d", mins))"
+            }
+        } else if rawValue == 0 {
+            return "At event"
+        } else {
+            if mins == 0 {
+                return "+\(hours):00"
+            } else {
+                return "+\(hours):\(String(format: "%02d", mins))"
+            }
+        }
+    }
+}
+
 public final class DMBSettings: ObservableObject {
-    
+
     private struct Keys {
         static let darknessThreshold = "darknessThreshold"
         static let isChangeSystemAppearanceBasedOnAmbientLightEnabled = "isChangeSystemAppearanceBasedOnAmbientLightEnabled"
@@ -19,6 +77,15 @@ public final class DMBSettings: ObservableObject {
         static let disableAppearanceChangeInClamshellMode = "disableAppearanceChangeInClamshellMode"
         static let enableImmediateChangeOnComputerWake = "enableImmediateChangeOnComputerWake"
         static let extraThresholdBeforeRevertingToLightMode = "extraThresholdBeforeRevertingToLightMode"
+
+        // Time scheduling keys
+        static let timeScheduleMode = "timeScheduleMode"
+        static let fixedStartHour = "fixedStartHour"
+        static let fixedStartMinute = "fixedStartMinute"
+        static let fixedEndHour = "fixedEndHour"
+        static let fixedEndMinute = "fixedEndMinute"
+        static let sunsetOffsetMinutes = "sunsetOffsetMinutes"
+        static let sunriseOffsetMinutes = "sunriseOffsetMinutes"
         
         static let defaultDarknessThreshold: Double = {
             DMBAmbientLightSensor.hardwareUsesLegacySensor() ? 20.0 : 52.0
@@ -50,15 +117,29 @@ public final class DMBSettings: ObservableObject {
             Keys.ambientLightSmoothingConstant: Keys.defaultAmbientLightSmoothingConstant,
             Keys.disableAppearanceChangeInClamshellMode: true,
             Keys.enableImmediateChangeOnComputerWake: true,
-            Keys.extraThresholdBeforeRevertingToLightMode: Keys.defaultExtraThresholdBeforeRevertingToLightMode
+            Keys.extraThresholdBeforeRevertingToLightMode: Keys.defaultExtraThresholdBeforeRevertingToLightMode,
+            Keys.timeScheduleMode: TimeScheduleMode.disabled.rawValue,
+            Keys.fixedStartHour: 18,
+            Keys.fixedStartMinute: 0,
+            Keys.fixedEndHour: 7,
+            Keys.fixedEndMinute: 0,
+            Keys.sunsetOffsetMinutes: SolarOffset.atEvent.rawValue,
+            Keys.sunriseOffsetMinutes: SolarOffset.atEvent.rawValue
         ])
-        
+
         self.isChangeSystemAppearanceBasedOnAmbientLightEnabled = defaults.bool(forKey: Keys.isChangeSystemAppearanceBasedOnAmbientLightEnabled)
         self.hasLaunchedAppBefore = defaults.bool(forKey: Keys.hasLaunchedAppBefore)
         self.darknessThreshold = defaults.optionalDoubleValue(forKey: Keys.darknessThreshold) ?? Keys.defaultDarknessThreshold
         self.darknessThresholdIntervalInSeconds = defaults.optionalDoubleValue(forKey: Keys.darknessThresholdIntervalInSeconds) ?? Keys.defaultDarknessThresholdIntervalInSeconds
         self.ambientLightSmoothingConstant = defaults.optionalDoubleValue(forKey: Keys.ambientLightSmoothingConstant) ?? Keys.defaultAmbientLightSmoothingConstant
         self.extraThresholdBeforeRevertingToLightMode = defaults.optionalDoubleValue(forKey: Keys.extraThresholdBeforeRevertingToLightMode) ?? Keys.defaultExtraThresholdBeforeRevertingToLightMode
+        self.timeScheduleMode = TimeScheduleMode(rawValue: defaults.integer(forKey: Keys.timeScheduleMode)) ?? .disabled
+        self.fixedStartHour = defaults.integer(forKey: Keys.fixedStartHour)
+        self.fixedStartMinute = defaults.integer(forKey: Keys.fixedStartMinute)
+        self.fixedEndHour = defaults.integer(forKey: Keys.fixedEndHour)
+        self.fixedEndMinute = defaults.integer(forKey: Keys.fixedEndMinute)
+        self.sunsetOffsetMinutes = defaults.integer(forKey: Keys.sunsetOffsetMinutes)
+        self.sunriseOffsetMinutes = defaults.integer(forKey: Keys.sunriseOffsetMinutes)
         
         if isPreviewing {
             self.isLaunchAtLoginEnabled = false
@@ -141,7 +222,46 @@ public final class DMBSettings: ObservableObject {
             )
         }
     }
-    
+
+    // MARK: - Time Scheduling
+
+    /// The mode for time-based scheduling of brightness threshold.
+    @Published public var timeScheduleMode: TimeScheduleMode {
+        didSet {
+            defaults.set(timeScheduleMode.rawValue, forKey: Keys.timeScheduleMode)
+        }
+    }
+
+    /// Fixed schedule start hour (0-23).
+    @Published public var fixedStartHour: Int {
+        didSet { defaults.set(fixedStartHour, forKey: Keys.fixedStartHour) }
+    }
+
+    /// Fixed schedule start minute (0-59).
+    @Published public var fixedStartMinute: Int {
+        didSet { defaults.set(fixedStartMinute, forKey: Keys.fixedStartMinute) }
+    }
+
+    /// Fixed schedule end hour (0-23).
+    @Published public var fixedEndHour: Int {
+        didSet { defaults.set(fixedEndHour, forKey: Keys.fixedEndHour) }
+    }
+
+    /// Fixed schedule end minute (0-59).
+    @Published public var fixedEndMinute: Int {
+        didSet { defaults.set(fixedEndMinute, forKey: Keys.fixedEndMinute) }
+    }
+
+    /// Offset in minutes from sunset for the schedule start.
+    @Published public var sunsetOffsetMinutes: Int {
+        didSet { defaults.set(sunsetOffsetMinutes, forKey: Keys.sunsetOffsetMinutes) }
+    }
+
+    /// Offset in minutes from sunrise for the schedule end.
+    @Published public var sunriseOffsetMinutes: Int {
+        didSet { defaults.set(sunriseOffsetMinutes, forKey: Keys.sunriseOffsetMinutes) }
+    }
+
     // MARK: - Launch at login
     
     private static var isAppInLoginItems: Bool {

--- a/DarkModeBuddyCore/Source/System/DMBSystemAppearanceSwitcher.swift
+++ b/DarkModeBuddyCore/Source/System/DMBSystemAppearanceSwitcher.swift
@@ -28,35 +28,96 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
     }
     
     private let log = OSLog(subsystem: kDarkModeBuddyCoreSubsystemName, category: String(describing: DMBSystemAppearanceSwitcher.self))
-    
+
     let settings: DMBSettings
     let reader: DMBAmbientLightSensorReader
-    
+    public var timeScheduleManager: TimeScheduleManager?
+
     private var cancellables = Set<AnyCancellable>()
-    
+
+    /// Tracks whether macOS Auto dark mode was enabled before we disabled it.
+    private static let savedAutoSwitchKey = "DMBSavedAppleInterfaceStyleSwitchesAutomatically"
+    private static let didOverrideAutoKey = "DMBDidOverrideAutoSwitch"
+
+    private var globalDefaults: UserDefaults? {
+        UserDefaults(suiteName: UserDefaults.globalDomain)
+    }
+
+    private var macOSAutoSwitchEnabled: Bool {
+        get {
+            globalDefaults?.bool(forKey: "AppleInterfaceStyleSwitchesAutomatically") ?? false
+        }
+        set {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+            process.arguments = ["write", "-g", "AppleInterfaceStyleSwitchesAutomatically", "-bool", newValue ? "true" : "false"]
+            try? process.run()
+            process.waitUntilExit()
+        }
+    }
+
     public init(settings: DMBSettings,
                 reader: DMBAmbientLightSensorReader = DMBAmbientLightSensorReader(frequency: .fast))
     {
         self.settings = settings
         self.reader = reader
     }
-    
+
     public func activate() {
         reader.$ambientLightValue.sink { [weak self] newValue in
             self?.ambientLightChanged(to: newValue)
         }.store(in: &cancellables)
-        
-        settings.$darknessThresholdIntervalInSeconds.sink { [weak self] _ in
+
+        settings.$darknessThresholdIntervalInSeconds.removeDuplicates().sink { [weak self] _ in
             self?.reset()
         }.store(in: &cancellables)
-        
-        settings.$darknessThreshold.sink { [weak self] _ in
+
+        settings.$darknessThreshold.removeDuplicates().sink { [weak self] _ in
             self?.reset()
         }.store(in: &cancellables)
-        
+
+        // Re-evaluate when the time schedule window changes
+        timeScheduleManager?.$isWithinSchedule.removeDuplicates().sink { [weak self] _ in
+            self?.reset()
+        }.store(in: &cancellables)
+
+        // Disable/restore macOS Auto when the toggle changes
+        settings.$isChangeSystemAppearanceBasedOnAmbientLightEnabled.sink { [weak self] enabled in
+            if enabled {
+                self?.disableMacOSAutoDarkMode()
+            } else {
+                self?.restoreMacOSAutoDarkMode()
+            }
+        }.store(in: &cancellables)
+
         setupUpdateAppearanceOnWake()
-        
+
         reader.activate()
+    }
+
+    // MARK: - macOS Auto Dark Mode Management
+
+    /// Disables macOS built-in Auto dark mode and saves its previous state.
+    private func disableMacOSAutoDarkMode() {
+        let wasAuto = macOSAutoSwitchEnabled
+        if wasAuto {
+            UserDefaults.standard.set(true, forKey: Self.savedAutoSwitchKey)
+            UserDefaults.standard.set(true, forKey: Self.didOverrideAutoKey)
+            macOSAutoSwitchEnabled = false
+            os_log("Disabled macOS Auto dark mode (was enabled)", log: log, type: .debug)
+        }
+    }
+
+    /// Restores macOS Auto dark mode to its previous state if we disabled it.
+    public func restoreMacOSAutoDarkMode() {
+        guard UserDefaults.standard.bool(forKey: Self.didOverrideAutoKey) else { return }
+        let savedValue = UserDefaults.standard.bool(forKey: Self.savedAutoSwitchKey)
+        if savedValue {
+            macOSAutoSwitchEnabled = true
+            os_log("Restored macOS Auto dark mode", log: log, type: .debug)
+        }
+        UserDefaults.standard.removeObject(forKey: Self.didOverrideAutoKey)
+        UserDefaults.standard.removeObject(forKey: Self.savedAutoSwitchKey)
     }
     
     private func setupUpdateAppearanceOnWake() {
@@ -114,13 +175,20 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
     private func evaluateAmbientLight(with value: Double) {
         #if DEBUG
         os_log("%{public}@ %{public}.2f", log: log, type: .debug, #function, value)
+        os_log("Candidate appearance is %@", log: self.log, type: .debug, candidateAppearance?.description ?? "")
         #endif
-        
+
         guard value != -1 else { return }
-        
+
         let newAppearance: Appearance
-        
-        if value < settings.darknessThreshold {
+
+        // If a time constraint is set and we're outside the window, force light mode.
+        // Otherwise, apply the normal brightness-based logic.
+        if let scheduleManager = timeScheduleManager, !scheduleManager.isWithinSchedule {
+            os_log("Outside time schedule, forcing light mode", log: self.log, type: .debug)
+            newAppearance = .light
+        } else if value < settings.darknessThreshold {
+            os_log("Below threshold %{public}.2f", log: self.log, type: .debug, settings.darknessThreshold)
             newAppearance = .dark
         } else {
             if Appearance.current == .dark {
@@ -128,6 +196,7 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
                     return
                 }
             }
+            os_log("Above threshold %{public}.2f", log: self.log, type: .debug, settings.darknessThreshold)
             newAppearance = .light
         }
         
@@ -153,7 +222,7 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
     
     private func changeSystemAppearance(to newAppearance: Appearance) {
         guard newAppearance != .current else { return }
-        
+
         if settings.isDisableAppearanceChangeInClamshellModeEnabled {
             guard !ClamshellStateChecker.isClamshellClosed() else {
                 os_log("Skipping appearance change because the Mac is in clamshell mode", log: self.log, type: .debug)
@@ -162,12 +231,12 @@ public final class DMBSystemAppearanceSwitcher: ObservableObject {
         }
 
         os_log("%{public}@ %{public}@", log: log, type: .debug, #function, newAppearance.description)
-        
+
         guard settings.isChangeSystemAppearanceBasedOnAmbientLightEnabled else {
             os_log("Automatic appearance change disabled in settings", log: self.log, type: .debug)
             return
         }
-        
+
         SLSSetAppearanceThemeLegacy(newAppearance.rawValue)
     }
     

--- a/DarkModeBuddyCore/Source/System/TimeScheduleManager.swift
+++ b/DarkModeBuddyCore/Source/System/TimeScheduleManager.swift
@@ -1,0 +1,156 @@
+//
+//  TimeScheduleManager.swift
+//  DarkModeBuddyCore
+//
+//  Determines whether the current time falls within the configured
+//  schedule window for ambient-light-based dark mode switching.
+//
+
+import Foundation
+import Combine
+import os.log
+
+public final class TimeScheduleManager: ObservableObject {
+
+    private let log = OSLog(subsystem: kDarkModeBuddyCoreSubsystemName, category: String(describing: TimeScheduleManager.self))
+
+    let settings: DMBSettings
+    let locationManager: LocationManager
+
+    @Published public var isWithinSchedule: Bool = true
+    @Published public var computedSunrise: Date?
+    @Published public var computedSunset: Date?
+
+    private var cancellables = Set<AnyCancellable>()
+    private var timer: Timer?
+
+    public init(settings: DMBSettings, locationManager: LocationManager) {
+        self.settings = settings
+        self.locationManager = locationManager
+    }
+
+    public func activate() {
+        // Re-evaluate whenever relevant settings or location change.
+        // .receive(on:) ensures evaluate() runs after @Published values
+        // are fully stored (willSet fires subscribers before storage).
+        Publishers.CombineLatest4(
+            settings.$timeScheduleMode,
+            settings.$fixedStartHour.combineLatest(settings.$fixedStartMinute),
+            settings.$fixedEndHour.combineLatest(settings.$fixedEndMinute),
+            settings.$sunsetOffsetMinutes.combineLatest(settings.$sunriseOffsetMinutes)
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in self?.evaluate() }
+        .store(in: &cancellables)
+
+        locationManager.$latitude.combineLatest(locationManager.$longitude)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.evaluate() }
+            .store(in: &cancellables)
+
+        // Re-evaluate every 60 seconds so we catch boundary transitions
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            self?.evaluate()
+        }
+
+        evaluate()
+    }
+
+    private func evaluate() {
+        let now = Date()
+
+        switch settings.timeScheduleMode {
+        case .disabled:
+            isWithinSchedule = true
+            computedSunrise = nil
+            computedSunset = nil
+
+        case .fixedTime:
+            isWithinSchedule = isWithinFixedWindow(now: now)
+            computedSunrise = nil
+            computedSunset = nil
+
+        case .solarRelative:
+            evaluateSolarRelative(now: now)
+        }
+    }
+
+    // MARK: - Fixed Time
+
+    private func isWithinFixedWindow(now: Date) -> Bool {
+        let cal = Calendar.current
+        let currentMinutes = cal.component(.hour, from: now) * 60 + cal.component(.minute, from: now)
+        let startMinutes = settings.fixedStartHour * 60 + settings.fixedStartMinute
+        let endMinutes = settings.fixedEndHour * 60 + settings.fixedEndMinute
+
+        if startMinutes <= endMinutes {
+            // Window within same day (e.g. 09:00 - 17:00)
+            return currentMinutes >= startMinutes && currentMinutes < endMinutes
+        } else {
+            // Window spans midnight (e.g. 18:00 - 07:00)
+            return currentMinutes >= startMinutes || currentMinutes < endMinutes
+        }
+    }
+
+    // MARK: - Solar Relative
+
+    private func evaluateSolarRelative(now: Date) {
+        guard let lat = locationManager.latitude, let lon = locationManager.longitude else {
+            os_log("No location available for solar calculation, falling back to always active", log: log, type: .debug)
+            isWithinSchedule = true
+            computedSunrise = nil
+            computedSunset = nil
+            return
+        }
+
+        // Compute for today
+        guard let solar = SolarCalculator.sunriseSunset(for: now, latitude: lat, longitude: lon) else {
+            os_log("Sun does not rise/set at this location today, falling back to always active", log: log, type: .debug)
+            isWithinSchedule = true
+            return
+        }
+
+        let adjustedSunset = solar.sunset.addingTimeInterval(Double(settings.sunsetOffsetMinutes) * 60.0)
+        let adjustedSunrise = solar.sunrise.addingTimeInterval(Double(settings.sunriseOffsetMinutes) * 60.0)
+
+        computedSunset = adjustedSunset
+        computedSunrise = adjustedSunrise
+
+        // The schedule window goes from adjustedSunset to adjustedSunrise (next day if needed)
+        if adjustedSunset <= adjustedSunrise {
+            // Unusual case: both on same day
+            isWithinSchedule = now >= adjustedSunset && now < adjustedSunrise
+        } else {
+            // Normal case: sunset today to sunrise tomorrow
+            // Also check yesterday's sunset to today's sunrise
+            let yesterdaySunrise = adjustedSunrise
+            let todaySunset = adjustedSunset
+
+            if now < yesterdaySunrise {
+                // Before today's sunrise - check if we're after yesterday's sunset
+                if let yesterdaySolar = SolarCalculator.sunriseSunset(
+                    for: now.addingTimeInterval(-86400), latitude: lat, longitude: lon
+                ) {
+                    let yesterdayAdjustedSunset = yesterdaySolar.sunset.addingTimeInterval(Double(settings.sunsetOffsetMinutes) * 60.0)
+                    isWithinSchedule = now >= yesterdayAdjustedSunset
+                } else {
+                    isWithinSchedule = true
+                }
+            } else if now >= todaySunset {
+                isWithinSchedule = true
+            } else {
+                isWithinSchedule = false
+            }
+        }
+
+        os_log(
+            "Solar schedule: sunset=%{public}@ sunrise=%{public}@ inWindow=%{public}@",
+            log: log, type: .debug,
+            adjustedSunset.description, adjustedSunrise.description, isWithinSchedule ? "YES" : "NO"
+        )
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+}

--- a/DarkModeBuddyCore/Source/Utilities/LocationManager.swift
+++ b/DarkModeBuddyCore/Source/Utilities/LocationManager.swift
@@ -1,0 +1,98 @@
+//
+//  LocationManager.swift
+//  DarkModeBuddyCore
+//
+//  Manages location access for solar calculations.
+//
+
+import Foundation
+import CoreLocation
+import Combine
+
+public final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+
+    private let manager = CLLocationManager()
+
+    @Published public var latitude: Double?
+    @Published public var longitude: Double?
+    @Published public var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    @Published public var locationError: String?
+
+    public var hasLocation: Bool { latitude != nil && longitude != nil }
+
+    public override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+        // authorizationStatus will be updated via the delegate callback
+        // which fires when the delegate is first assigned
+    }
+
+    public func requestPermission() {
+        manager.requestWhenInUseAuthorization()
+    }
+
+    public func requestLocation() {
+        guard isAuthorized else {
+            requestPermission()
+            return
+        }
+        fetchLocation()
+    }
+
+    private var isAuthorized: Bool {
+        let status: CLAuthorizationStatus
+        if #available(macOS 11.0, *) {
+            status = manager.authorizationStatus
+        } else {
+            status = CLLocationManager.authorizationStatus()
+        }
+        return status != .notDetermined && status != .denied && status != .restricted
+    }
+
+    private func fetchLocation() {
+        // Use cached location for immediate display
+        if let cached = manager.location {
+            latitude = cached.coordinate.latitude
+            longitude = cached.coordinate.longitude
+            locationError = nil
+        }
+        // Also request a fresh location update
+        manager.startUpdatingLocation()
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        latitude = location.coordinate.latitude
+        longitude = location.coordinate.longitude
+        locationError = nil
+        manager.stopUpdatingLocation()
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // Ignore transient "location unknown" errors — Core Location will keep trying
+        if let clError = error as? CLError, clError.code == .locationUnknown {
+            return
+        }
+        locationError = error.localizedDescription
+    }
+
+    // Modern delegate method (macOS 11+) — called when delegate is first set and on auth changes
+    @available(macOS 11.0, *)
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        authorizationStatus = manager.authorizationStatus
+        if isAuthorized {
+            fetchLocation()
+        }
+    }
+
+    // Legacy delegate method for macOS 10.15
+    public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        authorizationStatus = status
+        if isAuthorized {
+            fetchLocation()
+        }
+    }
+}

--- a/DarkModeBuddyCore/Source/Utilities/SolarCalculator.swift
+++ b/DarkModeBuddyCore/Source/Utilities/SolarCalculator.swift
@@ -1,0 +1,101 @@
+//
+//  SolarCalculator.swift
+//  DarkModeBuddyCore
+//
+//  Calculates sunrise and sunset times using the NOAA solar equations.
+//
+
+import Foundation
+
+public struct SolarCalculator {
+
+    /// Returns (sunrise, sunset) as Dates for the given date and location,
+    /// or nil if the sun doesn't rise or set at that location on that date.
+    public static func sunriseSunset(
+        for date: Date = Date(),
+        latitude: Double,
+        longitude: Double,
+        timeZone: TimeZone = .current
+    ) -> (sunrise: Date, sunset: Date)? {
+        let cal = Calendar.current
+        let dayOfYear = Double(cal.ordinality(of: .day, in: .year, for: date) ?? 1)
+        let year = cal.component(.year, from: date)
+
+        // Julian century from J2000.0
+        let jd = julianDay(year: year, dayOfYear: dayOfYear)
+        let jc = (jd - 2451545.0) / 36525.0
+
+        // Solar calculations
+        let geomMeanLongSun = fmod(280.46646 + jc * (36000.76983 + 0.0003032 * jc), 360.0)
+        let geomMeanAnomSun = 357.52911 + jc * (35999.05029 - 0.0001537 * jc)
+        let eccentEarthOrbit = 0.016708634 - jc * (0.000042037 + 0.0000001267 * jc)
+
+        let sunEqOfCtr = sin(radians(geomMeanAnomSun)) * (1.914602 - jc * (0.004817 + 0.000014 * jc))
+            + sin(radians(2.0 * geomMeanAnomSun)) * (0.019993 - 0.000101 * jc)
+            + sin(radians(3.0 * geomMeanAnomSun)) * 0.000289
+
+        let sunTrueLong = geomMeanLongSun + sunEqOfCtr
+        let sunAppLong = sunTrueLong - 0.00569 - 0.00478 * sin(radians(125.04 - 1934.136 * jc))
+
+        let meanObliqEcliptic = 23.0 + (26.0 + (21.448 - jc * (46.815 + jc * (0.00059 - jc * 0.001813))) / 60.0) / 60.0
+        let obliqCorr = meanObliqEcliptic + 0.00256 * cos(radians(125.04 - 1934.136 * jc))
+
+        let sinDeclination = sin(radians(obliqCorr)) * sin(radians(sunAppLong))
+        let declination = degrees(asin(sinDeclination))
+
+        let varY = tan(radians(obliqCorr / 2.0)) * tan(radians(obliqCorr / 2.0))
+
+        let eqOfTime = 4.0 * degrees(
+            varY * sin(2.0 * radians(geomMeanLongSun))
+            - 2.0 * eccentEarthOrbit * sin(radians(geomMeanAnomSun))
+            + 4.0 * eccentEarthOrbit * varY * sin(radians(geomMeanAnomSun)) * cos(2.0 * radians(geomMeanLongSun))
+            - 0.5 * varY * varY * sin(4.0 * radians(geomMeanLongSun))
+            - 1.25 * eccentEarthOrbit * eccentEarthOrbit * sin(2.0 * radians(geomMeanAnomSun))
+        )
+
+        // Hour angle for sunrise/sunset (solar zenith = 90.833°)
+        let zenith = 90.833
+        let cosHourAngle = (cos(radians(zenith)) / (cos(radians(latitude)) * cos(radians(declination))))
+            - tan(radians(latitude)) * tan(radians(declination))
+
+        // If cosHourAngle is out of [-1, 1], the sun doesn't rise or set
+        guard cosHourAngle >= -1.0 && cosHourAngle <= 1.0 else { return nil }
+
+        let hourAngle = degrees(acos(cosHourAngle))
+
+        let tzOffset = Double(timeZone.secondsFromGMT(for: date)) / 3600.0
+
+        // Solar noon in minutes from midnight
+        let solarNoon = (720.0 - 4.0 * longitude - eqOfTime + tzOffset * 60.0)
+
+        let sunriseMinutes = solarNoon - hourAngle * 4.0
+        let sunsetMinutes = solarNoon + hourAngle * 4.0
+
+        let startOfDay = cal.startOfDay(for: date)
+        let sunrise = startOfDay.addingTimeInterval(sunriseMinutes * 60.0)
+        let sunset = startOfDay.addingTimeInterval(sunsetMinutes * 60.0)
+
+        return (sunrise, sunset)
+    }
+
+    // MARK: - Helpers
+
+    private static func julianDay(year: Int, dayOfYear: Double) -> Double {
+        // Approximate Julian Day for Jan 1 of the given year + day offset
+        let a = Double(365 * (year + 4716))
+        let b = Double(Int(Double(year + 4716) / 4.0))  // not exact but close enough for century calc
+        // Use a simplified formula
+        let y = Double(year)
+        let jd0 = 367.0 * y - Double(Int(7.0 * (y + Double(Int((1.0 + 12.0) / 16.0))) / 4.0))
+            + Double(Int(275.0 * 1.0 / 9.0)) + 1721013.5 - 0.5
+        return jd0 + dayOfYear - 1.0
+    }
+
+    private static func radians(_ degrees: Double) -> Double {
+        degrees * .pi / 180.0
+    }
+
+    private static func degrees(_ radians: Double) -> Double {
+        radians * 180.0 / .pi
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds time-based scheduling capabilities to DarkModeBuddy, allowing users to restrict automatic dark mode switching to specific time windows. Users can choose between fixed time windows (e.g., 6 PM to 7 AM) or solar-relative scheduling (sunset to sunrise with customizable offsets). This also contains miscellaneous UI improvements.

<img width="532" height="644" alt="image" src="https://github.com/user-attachments/assets/1b0d4457-f61e-4615-ad98-60d1c887f073" />

## Key Changes

### New Modules
- **Time Schedule Modes**: Added three scheduling modes via `TimeScheduleMode` enum:
  - Disabled (always active)
  - Fixed time window (user-specified hours/minutes)
  - Solar-relative (sunset to sunrise with offset options)

- **Solar Calculations**: Implemented `SolarCalculator` using NOAA solar equations to compute sunrise/sunset times based on latitude/longitude

- **Location Management**: Added `LocationManager` to handle location permissions and coordinate retrieval for solar calculations

- **Time Schedule Manager**: New `TimeScheduleManager` class that:
  - Evaluates whether current time falls within the configured schedule
  - Handles both fixed and solar-relative scheduling logic
  - Updates every 60 seconds to catch boundary transitions
  - Publishes `isWithinSchedule` state for UI binding

### UI Improvements
- Redesigned settings view with expanded time constraints section
- Location permission request UI with error handling
- Enhanced status line showing:
  - Current mode status (active/inactive)
  - Next schedule boundary
  - Ambient light threshold and duration requirements
- Added visual light level indicator bar
- Improved label capitalization and spacing
- Non-linear duration slider with steps to ease configuration

### Settings & Storage
- Extended `DMBSettings` with new properties:
  - `timeScheduleMode`, `fixedStartHour/Minute`, `fixedEndHour/Minute`
  - `sunsetOffsetMinutes`, `sunriseOffsetMinutes`
  - Added `SolarOffset` enum with predefined offset options (-4h to +4h)

### System Integration
- Modified `DMBSystemAppearanceSwitcher` to:
  - Respect time schedule constraints before switching appearance
  - Disable/restore macOS built-in Auto dark mode when DarkModeBuddy is active
  - Re-evaluate on schedule boundary changes
- Updated app delegate to initialize and activate `TimeScheduleManager`
- Increased settings window size to accommodate new controls (420x580)

### Misc Technical Details
- Solar calculations handle edge cases (sun doesn't rise/set, midnight-spanning windows)
- Location caching for immediate display with background refresh
- Added location and calendar permissions to entitlements and Info.plist
- Preview mode detection to prevent sensor access during Xcode previews