### PR TITLE
Expand darkness threshold range to 30000 with non-linear slider

### DIFF
--- a/DarkModeBuddy/Views/SettingsView.swift
+++ b/DarkModeBuddy/Views/SettingsView.swift
@@ -12,7 +12,42 @@ struct SettingsView: View {
     @EnvironmentObject var reader: DMBAmbientLightSensorReader
     @EnvironmentObject var settings: DMBSettings
 
-    private let darknessInterval: ClosedRange<Double> = 0...3000
+    private let darknessInterval: ClosedRange<Double> = 0...30000
+
+    // Slider geometry: 80% of the track covers 0...6000 (fine control over the
+    // useful indoor range), the remaining 20% covers 6000...30000 for bright
+    // rooms and direct daylight.
+    private let darknessSliderBreakpointPosition: Double = 0.8
+    private let darknessSliderBreakpointValue: Double = 6000
+
+    private func value(forSliderPosition position: Double) -> Double {
+        let bp = darknessSliderBreakpointPosition
+        let bv = darknessSliderBreakpointValue
+        let maxV = darknessInterval.upperBound
+        if position <= bp {
+            return (position / bp) * bv
+        } else {
+            return bv + ((position - bp) / (1 - bp)) * (maxV - bv)
+        }
+    }
+
+    private func sliderPosition(forValue value: Double) -> Double {
+        let bp = darknessSliderBreakpointPosition
+        let bv = darknessSliderBreakpointValue
+        let maxV = darknessInterval.upperBound
+        if value <= bv {
+            return (value / bv) * bp
+        } else {
+            return bp + ((value - bv) / (maxV - bv)) * (1 - bp)
+        }
+    }
+
+    private var darknessThresholdSliderBinding: Binding<Double> {
+        Binding(
+            get: { sliderPosition(forValue: settings.darknessThreshold) },
+            set: { settings.darknessThreshold = value(forSliderPosition: $0) }
+        )
+    }
 
     @State private var isShowingDarknessValueOutOfBoundsAlert = false
     @State private var isEditingAmbientLightLevelManually = false
@@ -49,7 +84,7 @@ struct SettingsView: View {
                     Text("Go Dark When Ambient Light Falls Below:")
                     
                     HStack(alignment: .firstTextBaseline) {
-                        Slider(value: $settings.darknessThreshold, in: darknessInterval)
+                        Slider(value: darknessThresholdSliderBinding, in: 0...1)
                             .frame(maxWidth: 300)
                         if isEditingAmbientLightLevelManually {
                             TextField("", text: $editingAmbientLightManuallyTextFieldStore, onCommit: {


### PR DESCRIPTION
## Summary

The current cap of 3000 on the "Go Dark When Ambient Light Falls Below" slider is below the readings I see from brightly-lit indoor rooms (and anything close to direct daylight), so the threshold can't be set high enough for those environments.

Naively raising the cap would have made the slider's first ~90% of travel useless — the practical range for most users is roughly 0..2000. So this PR uses a piecewise-linear mapping instead:

- slider position `0.0..0.8` → value `0..6000` (fine indoor control)
- slider position `0.8..1.0` → value `6000..30000` (bright / daylight)

The stored `darknessThreshold` value, its persistence, and all downstream comparison logic are unchanged — the new mapping only affects how a slider position translates to a value. The numeric text field validator's upper bound moves from 3000 to 30000 to match.

## Test plan

- [x] Slider drags cleanly across the 0.8 breakpoint with no visible jump
- [x] Double-click the number → type 15000 → return; value accepted and stored
- [x] Threshold persists in `~/Library/Preferences/codes.rambo.DarkModeBuddy.plist` across relaunch
- [x] No changes to `DMBSettings` / framework / persistence format